### PR TITLE
Check for previously intended URL on login

### DIFF
--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -121,7 +121,10 @@ class Saml2Controller extends Controller
      */
     public function login()
     {
-        $this->saml2Auth->login(Config::get('saml2_settings.loginRoute'));
+        // check if there is a previously intended URL in current session
+        // fallback to loginRoute defined in SAML2 config file
+        $relayState = Session::pull('url.intended', Config::get('saml2_settings.loginRoute'));
+        $this->saml2Auth->login($relayState);
     }
 
 }


### PR DESCRIPTION
Check the current user session if a previously intended URL exist so this URL could be passed to the IDP as a relayState parameter.
The user will be redirected to this URL after login.