### PR TITLE
Sync with latest aacotroneo upstream, notably for onelogin v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
+  - 7.2
+
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
+
 
 before_script:
   - travis_retry composer self-update

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Alejandro Cotroneo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ The Saml2::login will redirect the user to the IDP and will came back to an endp
 ```php
 
  Event::listen('Aacotroneo\Saml2\Events\Saml2LoginEvent', function (Saml2LoginEvent $event) {
-
+            $messageId = $event->getSaml2Auth()->getLastMessageId();
+            // your own code preventing reuse of a $messageId to stop replay attacks
             $user = $event->getSaml2User();
             $userData = [
                 'id' => $user->getUserId(),

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ When you want your user to login, just call `Saml2Auth::login()` or redirect to 
 		}
 
 		return $next($request);
-	};
+	}
 ```
 
 The Saml2::login will redirect the user to the IDP and will came back to an endpoint the library serves at /saml2/acs. That will process the response and fire an event when ready. The next step for you is to handle that event. You just need to login the user or refuse.

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ The aim of this library is to be as simple as possible. We won't mess with Larav
 
 ## Installation - Composer
 
-To install Saml2 as a Composer package to be used with Laravel 5, simply run:
+You can install the package via composer:
 
 ```
 composer require aacotroneo/laravel-saml2
 ```
 
-Once it's installed, you can register the service provider in `config/app.php` in the `providers` array. If you want, you can add the alias saml2:
+If you are using Laravel 5.5 and up, the service provider will automatically get registered.
+
+For older versions of Laravel (<5.5), you have to add the service provider and alias to config/app.php:
 
 ```php
 'providers' => [

--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ To install Saml2 as a Composer package to be used with Laravel 5, simply run:
 composer require aacotroneo/laravel-saml2
 ```
 
-Once it's installed, you can register the service provider in `app/config/app.php` in the `providers` array. If you want, you can add the alias saml2:
+Once it's installed, you can register the service provider in `config/app.php` in the `providers` array. If you want, you can add the alias saml2:
 
 ```php
 'providers' => [
         ...
-    	'Aacotroneo\Saml2\Saml2ServiceProvider',
+    	Aacotroneo\Saml2\Saml2ServiceProvider::class,
 ]
 
 'alias' => [
         ...
-        'Saml2'     => 'Aacotroneo\Saml2\Facades\Saml2Auth',
+        'Saml2' => Aacotroneo\Saml2\Facades\Saml2Auth::class,
 ]
 ```
 
@@ -38,15 +38,15 @@ Once you publish your saml2_settings.php to your own files, you need to configur
 Remember that you don't need to implement those routes, but you'll need to add them to your IDP configuration. For example, if you use simplesamlphp, add the following to /metadata/sp-remote.php
 
 ```php
-$metadata['http://laravel_url/saml/metadata'] = array(
-    'AssertionConsumerService' => 'http://laravel_url/saml/acs',
-    'SingleLogoutService' => 'http://laravel_url/saml/sls',
+$metadata['http://laravel_url/saml2/metadata'] = array(
+    'AssertionConsumerService' => 'http://laravel_url/saml2/acs',
+    'SingleLogoutService' => 'http://laravel_url/saml2/sls',
     //the following two affect what the $Saml2user->getUserId() will return
     'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
     'simplesaml.nameidattribute' => 'uid' 
 );
 ```
-You can check that metadata if you actually navigate to 'http://laravel_url/saml/metadata'
+You can check that metadata if you actually navigate to 'http://laravel_url/saml2/metadata'
 
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ When you want your user to login, just call `Saml2Auth::login()` or redirect to 
 	}
 ```
 
+Since Laravel 5.3, you can change your unauthenticated method in ```app/Exceptions/Handler.php```.
+```php
+protected function unauthenticated($request, AuthenticationException $exception)
+{
+	if ($request->expectsJson())
+        {
+            return response()->json(['error' => 'Unauthenticated.'], 401);
+        }
+
+        return Saml2Auth::login();
+}
+```
+
 The Saml2::login will redirect the user to the IDP and will came back to an endpoint the library serves at /saml2/acs. That will process the response and fire an event when ready. The next step for you is to handle that event. You just need to login the user or refuse.
 
 ```php

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $metadata['http://laravel_url/saml/metadata'] = array(
     'simplesaml.nameidattribute' => 'uid' 
 );
 ```
-You can check that metadata if you actually navigate to 'http://laravel_url/saml/metadata'
+You can check that metadata if you actually navigate to 'http://laravel_url/saml2/metadata'
 
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once it's installed, you can register the service provider in `app/config/app.ph
 ]
 ```
 
-Then publish the config file with `php artisan vendor:publish`. This will add the file `app/config/saml2_settings.php`. This config is handled almost directly by  [OneLogin](https://github.com/onelogin/php-saml) so you may get further references there, but will cover here what's really necessary. There are some other config about routes you may want to check, they are pretty strightforward.
+Then publish the config file with `php artisan vendor:publish`. This will add the file `app/config/saml2_settings.php`. This config is handled almost directly by  [OneLogin](https://github.com/onelogin/php-saml) so you may get further references there, but will cover here what's really necessary. There are some other config about routes you may want to check, they are pretty straightforward.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ When you want your user to login, just call `Saml2Auth::login()` or redirect to 
 		}
 
 		return $next($request);
-	};
+	}
 ```
 
 The Saml2::login will redirect the user to the IDP and will came back to an endpoint the library serves at /saml2/acs. That will process the response and fire an event when ready. The next step for you is to handle that event. You just need to login the user or refuse.
@@ -77,7 +77,8 @@ The Saml2::login will redirect the user to the IDP and will came back to an endp
 ```php
 
  Event::listen('Aacotroneo\Saml2\Events\Saml2LoginEvent', function (Saml2LoginEvent $event) {
-
+            $messageId = $event->getSaml2Auth()->getLastMessageId();
+            // your own code preventing reuse of a $messageId to stop replay attacks
             $user = $event->getSaml2User();
             $userData = [
                 'id' => $user->getUserId(),

--- a/README.md
+++ b/README.md
@@ -11,54 +11,84 @@ The aim of this library is to be as simple as possible. We won't mess with Larav
 
 ## Installation - Composer
 
-To install Saml2 as a Composer package to be used with Laravel 5, simply add this to your composer.json:
+You can install the package via composer:
+
+```
+composer require nirajp/laravel-saml2
+```
+Or manually add this to your composer.json:
 
 ```json
 "nirajp/laravel-saml2": "*"
 ```
 
-..and run `composer update`.  Once it's installed, you can register the service provider in `app/config/app.php` in the `providers` array. If you want, you can add the alias saml2:
+If you are using Laravel 5.5 and up, the service provider will automatically get registered.
+
+For older versions of Laravel (<5.5), you have to add the service provider and alias to config/app.php:
 
 ```php
 'providers' => [
         ...
-    	'Aacotroneo\Saml2\Saml2ServiceProvider',
+    	Aacotroneo\Saml2\Saml2ServiceProvider::class,
 ]
 
 'alias' => [
         ...
-        'Saml2'     => 'Aacotroneo\Saml2\Facades\Saml2Auth',
+        'Saml2' => Aacotroneo\Saml2\Facades\Saml2Auth::class,
 ]
 ```
 
-Then publish the config files with `php artisan vendor:publish`. This will add the files `app/config/saml2_settings.php` & `app/config/saml2/test_idp_settings.php`. 
+Then publish the config files with `php artisan vendor:publish --provider="Aacotroneo\Saml2\Saml2ServiceProvider"`. This will add the files `app/config/saml2_settings.php` & `app/config/saml2/test_idp_settings.php`.
 
 The test_idp_settings.php config is handled almost directly by  [OneLogin](https://github.com/onelogin/php-saml) so you may get further references there, but will cover here what's really necessary. There are some other config about routes you may want to check, they are pretty strightforward.
 
 ### Configuration
 
-Define names of all the IDPs you want to configure in saml2_settings.php. Keep 'test' as the first IDP, and add real IDPs after that.
+#### Define the IDPs
+Define names of all the IDPs you want to configure in saml2_settings.php. Optionally keep 'test' as the first IDP if you want to use the simplesamlphp demo, and add real IDPs after that.
 
 ```php
     'idpNames' => ['test', 'myidp1', 'myidp2'],
 ```
 
-You will need to create a separate configuration file for each IDP under `app/config/saml2` folder. e.g. `myidp1_idp_settings.php`. You can use `test_idp_settings.php` as the starting point.
+#### Configure laravel-saml2 to know about each IDP
 
-The only real difference between this config and the one that OneLogin uses, is that the SP entityId, assertionConsumerService url and singleLogoutService URL are injected by the library. They are taken from routes 'saml_metadata', 'saml_acs' and 'saml_sls' respectively.
+You will need to create a separate configuration file for each IDP under `app/config/saml2/` folder. e.g. `myidp1_idp_settings.php`. You can use `test_idp_settings.php` as the starting point; just copy it to `app/config/saml2/` and rename it.
 
-Remember that you don't need to implement those routes, but you'll need to add them to your IDP configuration. For example, if you use simplesamlphp, add the following to /metadata/sp-remote.php
+Configuration options are note explained in this project as they come from the [OneLogin project](https://github.com/onelogin/php-saml), please refer there for details.
+
+The only real difference between this config and the one that OneLogin uses, is that the SP entityId, assertionConsumerService url and singleLogoutService URL are injected by the library. If you don't specify those URLs in the corresponding IDP config optional values, this library provides defaults values, the routes that this library creates for each IDP, which are given route names "{$idpName}_metadata", "{$idpName}_acs" and "{$idpName}_sls".
+
+If you want to define values in ENV vars instead of the \*\_idp_settings file, you'll see in there that the ENV values follow a naming pattern. For example, if in myipd1_idp_settings.php you set `$this_idp_env_id = 'MYIDP1';`, and in myidp2_idp_settings.php you set it to `'SECONDIDP'`, then you can set ENV vars starting with `SAML2_MYDP1_` and `SAML2_SECONDIDP_`, e.g.
+```env
+SAML2_MYIDP1_SP_x509="..."
+SAML2_MYIDP1_SP_PRIVATEKEY="..."
+// Other  SAML2_MYIDP1_* values
+
+SAML2_SECONDIDP_SP_x509="..."
+SAML2_SECONDIDP_SP_PRIVATEKEY="..."
+// Other SAML2_SECONDIDP_* values
+```
+
+#### URLs To Pass to The IDP configuration
+You don't need to implement the SP entityId, assertionConsumerService url and singleLogoutService routes, because Saml2Controller already does, but you'll need to provide them to the configuration of your actual IDP, i.e. the 3rd party you are asking to authenticate users.
+
+You can check the actual routes in the metadata, by navigating to 'http://laravel_url/myidp1/metadata' / 'https://laravel_url/myidp1/metadata', which incidentally will be the entityId for this SP.
+
+If you configure the optional `routesPrefix` setting in saml2_settings.php, then all idp routes will be prefixed by that value, so you'll need to adjust the metadata url accordingly. For example, if you configure routesPrefix to be `'single_sign_on'`, then your IDP metadata for myidp1 will be found at http://laravel_url/single_sign_on/myidp1/metadata.
+
+#### Exampl: simplesamlphp IDP configuration
+For example, if you use simplesamlphp, and your metadata url is `http://laravel_url/myidp1/metadata`, add the following to /metadata/sp-remote.php to inform the IDP of your laravel-saml2 SP identity:
 
 ```php
-$metadata['http://laravel_url/saml/metadata'] = array(
-    'AssertionConsumerService' => 'http://laravel_url/saml/acs',
-    'SingleLogoutService' => 'http://laravel_url/saml/sls',
+$metadata['http://laravel_url/myidp1/metadata'] = array(
+    'AssertionConsumerService' => 'http://laravel_url/myidp1/acs',
+    'SingleLogoutService' => 'http://laravel_url/myidp1/sls',
     //the following two affect what the $Saml2user->getUserId() will return
     'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
     'simplesaml.nameidattribute' => 'uid' 
 );
 ```
-You can check that metadata if you actually navigate to 'http://laravel_url/saml/metadata'
 
 
 ### Usage
@@ -81,14 +111,29 @@ When you want your user to login, just call `Saml2Auth::login()` or redirect to 
 		}
 
 		return $next($request);
-	};
+	}
 ```
 
-The Saml2::login will redirect the user to the IDP and will came back to an endpoint the library serves at /saml2/acs. That will process the response and fire an event when ready. The next step for you is to handle that event. You just need to login the user or refuse.
+Since Laravel 5.3, you can change your unauthenticated method in ```app/Exceptions/Handler.php```.
+```php
+protected function unauthenticated($request, AuthenticationException $exception)
+{
+	if ($request->expectsJson())
+        {
+            return response()->json(['error' => 'Unauthenticated.'], 401);
+        }
+
+        return Saml2Auth::login();
+}
+```
+
+The Saml2::login will redirect the user to the IDP and will came back to an endpoint the library serves at /myidp1/acs (or routesPrefix/myidp1/acs). That will process the response and fire an event when ready. The next step for you is to handle that event. You just need to login the user or refuse.
 
 ```php
 
  Event::listen('Aacotroneo\Saml2\Events\Saml2LoginEvent', function (Saml2LoginEvent $event) {
+            $messageId = $event->getSaml2Auth()->getLastMessageId();
+            // Add your own code preventing reuse of a $messageId to stop replay attacks
 
             $user = $event->getSaml2User();
             $userData = [
@@ -102,12 +147,44 @@ The Saml2::login will redirect the user to the IDP and will came back to an endp
         });
 
 ```
+### Auth persistence
+
+Becarefull about necessary Laravel middleware for Auth persistence in Session.
+
+For exemple, it can be:
+
+```
+# in App\Http\Kernel
+protected $middlewareGroups = [
+        'web' => [
+	    ...
+	],
+	'api' => [
+            ...
+        ],
+        'saml' => [
+            \App\Http\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+        ],
+
+```
+
+And in `config/saml2_settings.php` :
+```
+    /**
+     * which middleware group to use for the saml routes
+     * Laravel 5.2 will need a group which includes StartSession
+     */
+    'routesMiddleware' => ['saml'],
+```
+
 ### Log out
 Now there are two ways the user can log out.
  + 1 - By logging out in your app: In this case you 'should' notify the IDP first so it closes global session.
- + 2 - By logging out of the global SSO Session. In this case the IDP will notify you on /saml2/slo endpoint (already provided)
+ + 2 - By logging out of the global SSO Session. In this case the IDP will notify you on /myidp1/slo endpoint (already provided), if the IDP supports SLO
 
-For case 1 call `Saml2Auth::logout();` or redirect the user to the route 'saml_logout' which does just that. Do not close the session inmediately as you need to receive a response confirmation from the IDP (redirection). That response will be handled by the library at /saml2/sls and will fire an event for you to complete the operation.
+For case 1 call `Saml2Auth::logout();` or redirect the user to the logout route, e.g. 'myidp1_logout' which does just that. Do not close the session immediately as you need to receive a response confirmation from the IDP (redirection). That response will be handled by the library at /myidp1/sls and will fire an event for you to complete the operation.
 
 For case 2 you will only receive the event. Both cases 1 and 2 receive the same event. 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/aacotroneo/laravel-saml2.svg)](https://travis-ci.org/aacotroneo/laravel-saml2)
 
+[check https://github.com/aacotroneo/laravel-saml2/tree/remove_mcrypt for a mcrypt free version ]
+
 A Laravel package for Saml2 integration as a SP (service provider) based on  [OneLogin](https://github.com/onelogin/php-saml) toolkit, which is much lighter and easier to install than simplesamlphp SP. It doesn't need separate routes or session storage to work!
 
 The aim of this library is to be as simple as possible. We won't mess with Laravel users, auth, session...  We prefer to limit ourselves to a concrete task. Ask the user to authenticate at the IDP and process the response. Same case for SLO requests.

--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ To install Saml2 as a Composer package to be used with Laravel 5, simply run:
 composer require aacotroneo/laravel-saml2
 ```
 
-Once it's installed, you can register the service provider in `app/config/app.php` in the `providers` array. If you want, you can add the alias saml2:
+Once it's installed, you can register the service provider in `config/app.php` in the `providers` array. If you want, you can add the alias saml2:
 
 ```php
 'providers' => [
         ...
-    	'Aacotroneo\Saml2\Saml2ServiceProvider',
+    	Aacotroneo\Saml2\Saml2ServiceProvider::class,
 ]
 
 'alias' => [
         ...
-        'Saml2'     => 'Aacotroneo\Saml2\Facades\Saml2Auth',
+        'Saml2' => Aacotroneo\Saml2\Facades\Saml2Auth::class,
 ]
 ```
 
@@ -39,11 +39,11 @@ Remember that you don't need to implement those routes, but you'll need to add t
 
 ```php
 $metadata['http://laravel_url/saml2/metadata'] = array(
-'AssertionConsumerService' => 'http://laravel_url/saml2/acs',
-'SingleLogoutService' => 'http://laravel_url/saml2/sls',
-//the following two affect what the $Saml2user->getUserId() will return
-'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
-'simplesaml.nameidattribute' => 'uid'
+    'AssertionConsumerService' => 'http://laravel_url/saml2/acs',
+    'SingleLogoutService' => 'http://laravel_url/saml2/sls',
+    //the following two affect what the $Saml2user->getUserId() will return
+    'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+    'simplesaml.nameidattribute' => 'uid' 
 );
 ```
 You can check that metadata if you actually navigate to 'http://laravel_url/saml2/metadata'

--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@ The aim of this library is to be as simple as possible. We won't mess with Larav
 
 ## Installation - Composer
 
-To install Saml2 as a Composer package to be used with Laravel 5, simply run:
+You can install the package via composer:
+To install Saml2 via Composer run:
 
 ```
 composer require aacotroneo/laravel-saml2
 ```
 
-Once it's installed, you can register the service provider in `config/app.php` in the `providers` array. If you want, you can add the alias saml2:
+In Laravel 5.5 the service provider will automatically get registered.
+
+For versions of Laravel < 5.5, you have to add the service provider in `config/app.php` in the `providers` array and alias to `alias` array:
 
 ```php
 'providers' => [

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Build Status](https://travis-ci.org/aacotroneo/laravel-saml2.svg)](https://travis-ci.org/aacotroneo/laravel-saml2)
 
-[check https://github.com/aacotroneo/laravel-saml2/tree/remove_mcrypt for a mcrypt free version ]
-
 A Laravel package for Saml2 integration as a SP (service provider) based on  [OneLogin](https://github.com/onelogin/php-saml) toolkit, which is much lighter and easier to install than simplesamlphp SP. It doesn't need separate routes or session storage to work!
 
 The aim of this library is to be as simple as possible. We won't mess with Laravel users, auth, session...  We prefer to limit ourselves to a concrete task. Ask the user to authenticate at the IDP and process the response. Same case for SLO requests.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For older versions of Laravel (<5.5), you have to add the service provider and a
 ]
 ```
 
-Then publish the config file with `php artisan vendor:publish`. This will add the file `app/config/saml2_settings.php`. This config is handled almost directly by  [OneLogin](https://github.com/onelogin/php-saml) so you may get further references there, but will cover here what's really necessary. There are some other config about routes you may want to check, they are pretty straightforward.
+Then publish the config file with `php artisan vendor:publish --provider="Aacotroneo\Saml2\Saml2ServiceProvider"`. This will add the file `app/config/saml2_settings.php`. This config is handled almost directly by  [OneLogin](https://github.com/onelogin/php-saml) so you may get further references there, but will cover here what's really necessary. There are some other config about routes you may want to check, they are pretty straightforward.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,38 @@ The Saml2::login will redirect the user to the IDP and will came back to an endp
         });
 
 ```
+### Auth persistence
+
+Becarefull about necessary Laravel middleware for Auth persistence in Session.
+
+For exemple, it can be:
+
+```
+# in App\Http\Kernel
+protected $middlewareGroups = [
+        'web' => [
+	    ...
+	],
+	'api' => [
+            ...
+        ],
+        'saml' => [
+            \App\Http\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+        ],
+
+```
+
+And in `config/saml2_settings.php` :
+```
+    /**
+     * which middleware group to use for the saml routes
+     * Laravel 5.2 will need a group which includes StartSession
+     */
+    'routesMiddleware' => ['saml'],
+```
+
 ### Log out
 Now there are two ways the user can log out.
  + 1 - By logging out in your app: In this case you 'should' notify the IDP first so it closes global session.

--- a/README.md
+++ b/README.md
@@ -10,15 +10,14 @@ The aim of this library is to be as simple as possible. We won't mess with Larav
 ## Installation - Composer
 
 You can install the package via composer:
-To install Saml2 via Composer run:
 
 ```
 composer require aacotroneo/laravel-saml2
 ```
 
-In Laravel 5.5 the service provider will automatically get registered.
+If you are using Laravel 5.5 and up, the service provider will automatically get registered.
 
-For versions of Laravel < 5.5, you have to add the service provider in `config/app.php` in the `providers` array and alias to `alias` array:
+For older versions of Laravel (<5.5), you have to add the service provider and alias to config/app.php:
 
 ```php
 'providers' => [

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ Once you publish your saml2_settings.php to your own files, you need to configur
 Remember that you don't need to implement those routes, but you'll need to add them to your IDP configuration. For example, if you use simplesamlphp, add the following to /metadata/sp-remote.php
 
 ```php
-$metadata['http://laravel_url/saml/metadata'] = array(
-    'AssertionConsumerService' => 'http://laravel_url/saml/acs',
-    'SingleLogoutService' => 'http://laravel_url/saml/sls',
-    //the following two affect what the $Saml2user->getUserId() will return
-    'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
-    'simplesaml.nameidattribute' => 'uid' 
+$metadata['http://laravel_url/saml2/metadata'] = array(
+'AssertionConsumerService' => 'http://laravel_url/saml2/acs',
+'SingleLogoutService' => 'http://laravel_url/saml2/sls',
+//the following two affect what the $Saml2user->getUserId() will return
+'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+'simplesaml.nameidattribute' => 'uid'
 );
 ```
 You can check that metadata if you actually navigate to 'http://laravel_url/saml2/metadata'

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ The aim of this library is to be as simple as possible. We won't mess with Larav
 
 ## Installation - Composer
 
-To install Saml2 as a Composer package to be used with Laravel 4, simply add this to your composer.json:
+To install Saml2 as a Composer package to be used with Laravel 5, simply run:
 
-```json
-"aacotroneo/laravel-saml2": "*"
+```
+composer require aacotroneo/laravel-saml2
 ```
 
-..and run `composer update`.  Once it's installed, you can register the service provider in `app/config/app.php` in the `providers` array. If you want, you can add the alias saml2:
+Once it's installed, you can register the service provider in `app/config/app.php` in the `providers` array. If you want, you can add the alias saml2:
 
 ```php
 'providers' => [

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once it's installed, you can register the service provider in `config/app.php` i
 ]
 ```
 
-Then publish the config file with `php artisan vendor:publish`. This will add the file `app/config/saml2_settings.php`. This config is handled almost directly by  [OneLogin](https://github.com/onelogin/php-saml) so you may get further references there, but will cover here what's really necessary. There are some other config about routes you may want to check, they are pretty strightforward.
+Then publish the config file with `php artisan vendor:publish`. This will add the file `app/config/saml2_settings.php`. This config is handled almost directly by  [OneLogin](https://github.com/onelogin/php-saml) so you may get further references there, but will cover here what's really necessary. There are some other config about routes you may want to check, they are pretty straightforward.
 
 ### Configuration
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/aacotroneo/laravel-saml2",
     "license": "MIT",
-    "version": "0.11.1",
+    "version": "1.0.0",
     "authors": [
         {
             "name": "aacotroneo",

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/nirajp/laravel-saml2",
     "license": "MIT",
+    "version": "1.0.0",
     "authors": [
         {
             "name": "aacotroneo",
@@ -16,8 +17,9 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-openssl": "*",
         "illuminate/support": ">=5.0.0",
-        "onelogin/php-saml": "2.9.1"
+        "onelogin/php-saml": "^3.0.0"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
@@ -26,6 +28,16 @@
     "autoload": {
         "psr-0": {
             "Aacotroneo\\Saml2\\": "src/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Aacotroneo\\Saml2\\Saml2ServiceProvider"
+            ],
+            "aliases": {
+                "Saml2": "Aacotroneo\\Saml2\\Facades\\Saml2Auth"
+            }
         }
     },
     "minimum-stability": "stable"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.4.0",
         "ext-openssl": "*",
         "illuminate/support": ">=5.0.0",
-        "onelogin/php-saml": "^2.10"
+        "onelogin/php-saml": "^3.0.0"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/aacotroneo/laravel-saml2",
     "license": "MIT",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "authors": [
         {
             "name": "aacotroneo",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/aacotroneo/laravel-saml2",
     "license": "MIT",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "authors": [
         {
             "name": "aacotroneo",
@@ -13,6 +13,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-openssl": "*",
         "illuminate/support": ">=5.0.0",
         "onelogin/php-saml": "^2.10"
     },
@@ -22,6 +23,16 @@
     "autoload": {
         "psr-0": {
             "Aacotroneo\\Saml2\\": "src/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Aacotroneo\\Saml2\\Saml2ServiceProvider"
+            ],
+            "aliases": {
+                "Saml2": "Aacotroneo\\Saml2\\Facades\\Saml2Auth"
+            }
         }
     },
     "minimum-stability": "stable"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": ">=5.0.0",
-        "onelogin/php-saml": "2.*"
+        "onelogin/php-saml": "^2.10"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/aacotroneo/laravel-saml2",
     "license": "MIT",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "authors": [
         {
             "name": "aacotroneo",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/aacotroneo/laravel-saml2",
     "license": "MIT",
-    "version": "0.8.1",
+    "version": "0.9.0",
     "authors": [
         {
             "name": "aacotroneo",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/aacotroneo/laravel-saml2",
     "license": "MIT",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "authors": [
         {
             "name": "aacotroneo",

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-openssl": "*",
         "illuminate/support": ">=5.0.0",
         "onelogin/php-saml": "^2.10"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,15 +24,5 @@
             "Aacotroneo\\Saml2\\": "src/"
         }
     },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Aacotroneo\\Saml2\\Saml2ServiceProvider"
-            ],
-            "aliases": {
-                "Saml2": "Aacotroneo\\Saml2\\Facades\\Saml2Auth"
-            }
-        }
-    },
     "minimum-stability": "stable"
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/aacotroneo/laravel-saml2",
     "license": "MIT",
-    "version": "0.11.1",
+    "version": "1.0.0",
     "authors": [
         {
             "name": "aacotroneo",
@@ -15,7 +15,7 @@
         "php": ">=5.4.0",
         "ext-openssl": "*",
         "illuminate/support": ">=5.0.0",
-        "onelogin/php-saml": "^2.10"
+        "onelogin/php-saml": "^3.0.0"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/aacotroneo/laravel-saml2",
     "license": "MIT",
-    "version": "0.9.1",
+    "version": "0.10.0",
     "authors": [
         {
             "name": "aacotroneo",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/aacotroneo/laravel-saml2",
     "license": "MIT",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "authors": [
         {
             "name": "aacotroneo",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": ">=5.0.0",
-        "onelogin/php-saml": "2.9.1"
+        "onelogin/php-saml": "2.*"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*"

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,15 @@
             "Aacotroneo\\Saml2\\": "src/"
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Aacotroneo\\Saml2\\Saml2ServiceProvider"
+            ],
+            "aliases": {
+                "Saml2": "Aacotroneo\\Saml2\\Facades\\Saml2Auth"
+            }
+        }
+    },
     "minimum-stability": "stable"
 }

--- a/src/Aacotroneo/Saml2/Events/Saml2LoginEvent.php
+++ b/src/Aacotroneo/Saml2/Events/Saml2LoginEvent.php
@@ -2,14 +2,19 @@
 
 namespace Aacotroneo\Saml2\Events;
 
+use Aacotroneo\Saml2\Saml2User;
+use Aacotroneo\Saml2\Saml2Auth;
+
 class Saml2LoginEvent extends Saml2Event {
 
     protected $user;
+    protected $auth;
 
-    function __construct($idp, $user)
+    function __construct($idp, Saml2User $user, Saml2Auth $auth)
     {
         parent::__construct($idp);
         $this->user = $user;
+        $this->auth = $auth;
     }
 
     public function getSaml2User()
@@ -17,4 +22,8 @@ class Saml2LoginEvent extends Saml2Event {
         return $this->user;
     }
 
+    public function getSaml2Auth()
+    {
+        return $this->auth;
+    }
 }

--- a/src/Aacotroneo/Saml2/Events/Saml2LoginEvent.php
+++ b/src/Aacotroneo/Saml2/Events/Saml2LoginEvent.php
@@ -2,13 +2,18 @@
 
 namespace Aacotroneo\Saml2\Events;
 
+use Aacotroneo\Saml2\Saml2User;
+use Aacotroneo\Saml2\Saml2Auth;
+
 class Saml2LoginEvent {
 
     protected $user;
+    protected $auth;
 
-    function __construct($user)
+    function __construct(Saml2User $user, Saml2Auth $auth)
     {
         $this->user = $user;
+        $this->auth = $auth;
     }
 
     public function getSaml2User()
@@ -16,6 +21,9 @@ class Saml2LoginEvent {
         return $this->user;
     }
 
-
+    public function getSaml2Auth()
+    {
+        return $this->auth;
+    }
 
 }

--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -66,7 +66,7 @@ class Saml2Controller extends Controller
 
     /**
      * Process an incoming saml2 logout request.
-     * Fires 'saml2.logoutRequestReceived' event if its valid.
+     * Fires 'Saml2LogoutEvent' event if its valid.
      * This means the user logged out of the SSO infrastructure, you 'should' log him out locally too.
      */
     public function sls()

--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -6,7 +6,7 @@ use Aacotroneo\Saml2\Events\Saml2LoginEvent;
 use Aacotroneo\Saml2\Saml2Auth;
 use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
-use OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
 use URL;
 
 class Saml2Controller extends Controller
@@ -21,18 +21,34 @@ class Saml2Controller extends Controller
      */
     function __construct(Request $request){
 
-        $this->idp = explode('/',$request->path())[0];
+        // IdP name is *2nd-to-last* item in path, whether no routesPrefix ("idpName/page") or using routesPrefix ("routesPrefix/idpName/page")
+        $pathSegments = $request->segments();
+        $this->idp = $pathSegments[count($pathSegments)-2];
         if (!$this->idp) {
             $this->idp = 'test';
         }
 
         $config = config('saml2.'.$this->idp.'_idp_settings');
 
-        $config['sp']['entityId'] = URL::route($this->idp.'_metadata');
-
-        $config['sp']['assertionConsumerService']['url'] = URL::route($this->idp.'_acs');
-
-        $config['sp']['singleLogoutService']['url'] = URL::route($this->idp.'_sls');
+        if (empty($config['sp']['entityId'])) {
+            $config['sp']['entityId'] = URL::route($this->idp.'_metadata');
+        }
+        if (empty($config['sp']['assertionConsumerService']['url'])) {
+            $config['sp']['assertionConsumerService']['url'] = URL::route($this->idp.'_acs');
+        }
+        if (!empty($config['sp']['singleLogoutService']) &&
+            empty($config['sp']['singleLogoutService']['url'])) {
+            $config['sp']['singleLogoutService']['url'] = URL::route($this->idp.'_sls');
+        }
+        if (strpos($config['sp']['privateKey'], 'file://')===0) {
+            $config['sp']['privateKey'] = $this->extractPkeyFromFile($config['sp']['privateKey']);
+        }
+        if (strpos($config['sp']['x509cert'], 'file://')===0) {
+            $config['sp']['x509cert'] = $this->extractCertFromFile($config['sp']['x509cert']);
+        }
+        if (strpos($config['idp']['x509cert'], 'file://')===0) {
+            $config['idp']['x509cert'] = $this->extractCertFromFile($config['idp']['x509cert']);
+        }
 
         $auth = new OneLogin_Saml2_Auth($config);
 
@@ -53,20 +69,23 @@ class Saml2Controller extends Controller
 
     /**
      * Process an incoming saml2 assertion request.
-     * Fires 'saml2.loginRequestReceived' event if a valid user is Found
+     * Fires 'Saml2LoginEvent' event if a valid user is Found
      */
     public function acs()
     {
         $errors = $this->saml2Auth->acs();
 
         if (!empty($errors)) {
+            logger()->error('Saml2 error_detail', ['error' => $this->saml2Auth->getLastErrorReason()]);
+            session()->flash('saml2_error_detail', [$this->saml2Auth->getLastErrorReason()]);
+
             logger()->error('Saml2 error', $errors);
             session()->flash('saml2_error', $errors);
             return redirect(config('saml2_settings.errorRoute'));
         }
         $user = $this->saml2Auth->getSaml2User();
 
-        event(new Saml2LoginEvent($this->idp, $user));
+        event(new Saml2LoginEvent($this->idp, $user, $this->saml2Auth));
 
         $redirectUrl = $user->getIntendedUrl();
 
@@ -80,7 +99,7 @@ class Saml2Controller extends Controller
 
     /**
      * Process an incoming saml2 logout request.
-     * Fires 'saml2.logoutRequestReceived' event if its valid.
+     * Fires 'Saml2LogoutEvent' event if its valid.
      * This means the user logged out of the SSO infrastructure, you 'should' log him out locally too.
      */
     public function sls()
@@ -116,4 +135,30 @@ class Saml2Controller extends Controller
         $this->saml2Auth->login(config('saml2_settings.loginRoute'));
     }
 
+    protected function extractPkeyFromFile($path) {
+        $res = openssl_get_privatekey($path);
+        if (empty($res)) {
+            throw new \Exception('Could not read private key-file at path \'' . $path . '\'');
+        }
+        openssl_pkey_export($res, $pkey);
+        openssl_pkey_free($res);
+        return $this->extractOpensslString($pkey, 'PRIVATE KEY');
+    }
+
+    protected function extractCertFromFile($path) {
+        $res = openssl_x509_read(file_get_contents($path));
+        if (empty($res)) {
+            throw new \Exception('Could not read X509 certificate-file at path \'' . $path . '\'');
+        }
+        openssl_x509_export($res, $cert);
+        openssl_x509_free($res);
+        return $this->extractOpensslString($cert, 'CERTIFICATE');
+    }
+
+    protected function extractOpensslString($keyString, $delimiter) {
+        $keyString = str_replace(["\r", "\n"], "", $keyString);
+        $regex = '/-{5}BEGIN(?:\s|\w)+' . $delimiter . '-{5}\s*(.+?)\s*-{5}END(?:\s|\w)+' . $delimiter . '-{5}/m';
+        preg_match($regex, $keyString, $matches);
+        return empty($matches[1]) ? '' : $matches[1];
+    }
 }

--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -43,13 +43,16 @@ class Saml2Controller extends Controller
         $errors = $this->saml2Auth->acs();
 
         if (!empty($errors)) {
+            logger()->error('Saml2 error_detail', ['error' => $this->saml2Auth->getLastErrorReason()]);
+            session()->flash('saml2_error_detail', [$this->saml2Auth->getLastErrorReason()]);
+
             logger()->error('Saml2 error', $errors);
             session()->flash('saml2_error', $errors);
             return redirect(config('saml2_settings.errorRoute'));
         }
         $user = $this->saml2Auth->getSaml2User();
 
-        event(new Saml2LoginEvent($user));
+        event(new Saml2LoginEvent($user, $this->saml2Auth));
 
         $redirectUrl = $user->getIntendedUrl();
 

--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -43,6 +43,9 @@ class Saml2Controller extends Controller
         $errors = $this->saml2Auth->acs();
 
         if (!empty($errors)) {
+            logger()->error('Saml2 error_detail', ['error' => $this->saml2Auth->getLastErrorReason()]);
+            session()->flash('saml2_error_detail', [$this->saml2Auth->getLastErrorReason()]);
+
             logger()->error('Saml2 error', $errors);
             session()->flash('saml2_error', $errors);
             return redirect(config('saml2_settings.errorRoute'));

--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -52,7 +52,7 @@ class Saml2Controller extends Controller
         }
         $user = $this->saml2Auth->getSaml2User();
 
-        event(new Saml2LoginEvent($user));
+        event(new Saml2LoginEvent($user, $this->saml2Auth));
 
         $redirectUrl = $user->getIntendedUrl();
 

--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -36,7 +36,7 @@ class Saml2Controller extends Controller
 
     /**
      * Process an incoming saml2 assertion request.
-     * Fires 'saml2.loginRequestReceived' event if a valid user is Found
+     * Fires 'Saml2LoginEvent' event if a valid user is Found
      */
     public function acs()
     {

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -2,9 +2,9 @@
 
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
-use OneLogin_Saml2_Error;
-use OneLogin_Saml2_Utils;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Error as OneLogin_Saml2_Error;
+use OneLogin\Saml2\Utils as OneLogin_Saml2_Utils;
 use Aacotroneo\Saml2\Events\Saml2LogoutEvent;
 
 use Log;
@@ -45,25 +45,54 @@ class Saml2Auth
     }
 
     /**
+     * The ID of the last message processed
+     * @return String
+     */
+    function getLastMessageId()
+    {
+        return $this->auth->getLastMessageId();
+    }
+
+    /**
      * Initiate a saml2 login flow. It will redirect! Before calling this, check if user is
      * authenticated (here in saml2). That would be true when the assertion was received this request.
+     *
+     * @param string|null $returnTo        The target URL the user should be returned to after login.
+     * @param array       $parameters      Extra parameters to be added to the GET
+     * @param bool        $forceAuthn      When true the AuthNReuqest will set the ForceAuthn='true'
+     * @param bool        $isPassive       When true the AuthNReuqest will set the Ispassive='true'
+     * @param bool        $stay            True if we want to stay (returns the url string) False to redirect
+     * @param bool        $setNameIdPolicy When true the AuthNReuqest will set a nameIdPolicy element
+     *
+     * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      */
-    function login($returnTo = null)
+    function login($returnTo = null, $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true)
     {
         $auth = $this->auth;
 
-        $auth->login($returnTo);
+        return $auth->login($returnTo, $parameters, $forceAuthn, $isPassive, $stay, $setNameIdPolicy);
     }
 
     /**
      * Initiate a saml2 logout flow. It will close session on all other SSO services. You should close
      * local session if applicable.
+     *
+     * @param string|null $returnTo            The target URL the user should be returned to after logout.
+     * @param string|null $nameId              The NameID that will be set in the LogoutRequest.
+     * @param string|null $sessionIndex        The SessionIndex (taken from the SAML Response in the SSO process).
+     * @param string|null $nameIdFormat        The NameID Format will be set in the LogoutRequest.
+     * @param bool        $stay            True if we want to stay (returns the url string) False to redirect
+     * @param string|null $nameIdNameQualifier The NameID NameQualifier will be set in the LogoutRequest.
+     *
+     * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
+     *
+     * @throws OneLogin_Saml2_Error
      */
-    function logout($returnTo = null, $nameId = null, $sessionIndex = null)
+    function logout($returnTo = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null, $stay = false, $nameIdNameQualifier = null)
     {
         $auth = $this->auth;
 
-        $auth->logout($returnTo, [], $nameId, $sessionIndex);
+        return $auth->logout($returnTo, [], $nameId, $sessionIndex, $stay, $nameIdFormat, $nameIdNameQualifier);
     }
 
     /**
@@ -142,5 +171,12 @@ class Saml2Auth
         }
     }
 
-
+    /**
+     * Get the last error reason from \OneLogin_Saml2_Auth, useful for error debugging.
+     * @see \OneLogin_Saml2_Auth::getLastErrorReason()
+     * @return string
+     */
+    function getLastErrorReason() {
+        return $this->auth->getLastErrorReason();
+    }
 }

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -81,16 +81,18 @@ class Saml2Auth
      * @param string|null $nameId              The NameID that will be set in the LogoutRequest.
      * @param string|null $sessionIndex        The SessionIndex (taken from the SAML Response in the SSO process).
      * @param string|null $nameIdFormat        The NameID Format will be set in the LogoutRequest.
+     * @param bool        $stay            True if we want to stay (returns the url string) False to redirect
+     * @param string|null $nameIdNameQualifier The NameID NameQualifier will be set in the LogoutRequest.
      *
      * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      *
      * @throws OneLogin_Saml2_Error
      */
-    function logout($returnTo = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null)
+    function logout($returnTo = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null, $stay = false, $nameIdNameQualifier = null)
     {
         $auth = $this->auth;
 
-        $auth->logout($returnTo, [], $nameId, $sessionIndex, false, $nameIdFormat);
+        return $auth->logout($returnTo, [], $nameId, $sessionIndex, $stay, $nameIdFormat, $nameIdNameQualifier);
     }
 
     /**

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -45,6 +45,15 @@ class Saml2Auth
     }
 
     /**
+     * The ID of the last message processed
+     * @return String
+     */
+    function getLastMessageId()
+    {
+        return $this->auth->getLastMessageId();
+    }
+
+    /**
      * Initiate a saml2 login flow. It will redirect! Before calling this, check if user is
      * authenticated (here in saml2). That would be true when the assertion was received this request.
      */
@@ -137,5 +146,12 @@ class Saml2Auth
         }
     }
 
-
+    /**
+     * Get the last error reason from \OneLogin_Saml2_Auth, useful for error debugging.
+     * @see \OneLogin_Saml2_Auth::getLastErrorReason()
+     * @return string
+     */
+    function getLastErrorReason() {
+        return $this->auth->getLastErrorReason();
+    }
 }

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -68,11 +68,11 @@ class Saml2Auth
      * Initiate a saml2 logout flow. It will close session on all other SSO services. You should close
      * local session if applicable.
      */
-    function logout($returnTo = null, $nameId = null, $sessionIndex = null)
+    function logout($returnTo = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null)
     {
         $auth = $this->auth;
 
-        $auth->logout($returnTo, [], $nameId, $sessionIndex);
+        $auth->logout($returnTo, [], $nameId, $sessionIndex, false, $nameIdFormat);
     }
 
     /**

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -45,6 +45,15 @@ class Saml2Auth
     }
 
     /**
+     * The ID of the last message processed
+     * @return String
+     */
+    function getLastMessageId()
+    {
+        return $this->auth->getLastMessageId();
+    }
+
+    /**
      * Initiate a saml2 login flow. It will redirect! Before calling this, check if user is
      * authenticated (here in saml2). That would be true when the assertion was received this request.
      */

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -57,11 +57,11 @@ class Saml2Auth
      * Initiate a saml2 login flow. It will redirect! Before calling this, check if user is
      * authenticated (here in saml2). That would be true when the assertion was received this request.
      */
-    function login($returnTo = null, $parameters = array())
+    function login($returnTo = null, $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true)
     {
         $auth = $this->auth;
 
-        $auth->login($returnTo, $parameters);
+        $auth->login($returnTo, $parameters, $forceAuthn, $isPassive, $stay, $setNameIdPolicy);
     }
 
     /**

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -56,17 +56,35 @@ class Saml2Auth
     /**
      * Initiate a saml2 login flow. It will redirect! Before calling this, check if user is
      * authenticated (here in saml2). That would be true when the assertion was received this request.
+     *
+     * @param string|null $returnTo        The target URL the user should be returned to after login.
+     * @param array       $parameters      Extra parameters to be added to the GET
+     * @param bool        $forceAuthn      When true the AuthNReuqest will set the ForceAuthn='true'
+     * @param bool        $isPassive       When true the AuthNReuqest will set the Ispassive='true'
+     * @param bool        $stay            True if we want to stay (returns the url string) False to redirect
+     * @param bool        $setNameIdPolicy When true the AuthNReuqest will set a nameIdPolicy element
+     *
+     * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      */
     function login($returnTo = null, $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true)
     {
         $auth = $this->auth;
 
-        $auth->login($returnTo, $parameters, $forceAuthn, $isPassive, $stay, $setNameIdPolicy);
+        return $auth->login($returnTo, $parameters, $forceAuthn, $isPassive, $stay, $setNameIdPolicy);
     }
 
     /**
      * Initiate a saml2 logout flow. It will close session on all other SSO services. You should close
      * local session if applicable.
+     *
+     * @param string|null $returnTo            The target URL the user should be returned to after logout.
+     * @param string|null $nameId              The NameID that will be set in the LogoutRequest.
+     * @param string|null $sessionIndex        The SessionIndex (taken from the SAML Response in the SSO process).
+     * @param string|null $nameIdFormat        The NameID Format will be set in the LogoutRequest.
+     *
+     * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
+     *
+     * @throws OneLogin_Saml2_Error
      */
     function logout($returnTo = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null)
     {

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -48,11 +48,11 @@ class Saml2Auth
      * Initiate a saml2 login flow. It will redirect! Before calling this, check if user is
      * authenticated (here in saml2). That would be true when the assertion was received this request.
      */
-    function login($returnTo = null)
+    function login($returnTo = null, $parameters = array())
     {
         $auth = $this->auth;
 
-        $auth->login($returnTo);
+        $auth->login($returnTo, $parameters);
     }
 
     /**

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -137,5 +137,12 @@ class Saml2Auth
         }
     }
 
-
+    /**
+     * Get the last error reason from \OneLogin_Saml2_Auth, useful for error debugging.
+     * @see \OneLogin_Saml2_Auth::getLastErrorReason()
+     * @return string
+     */
+    function getLastErrorReason() {
+        return $this->auth->getLastErrorReason();
+    }
 }

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -2,9 +2,9 @@
 
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
-use OneLogin_Saml2_Error;
-use OneLogin_Saml2_Utils;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Error as OneLogin_Saml2_Error;
+use OneLogin\Saml2\Utils as OneLogin_Saml2_Utils;
 use Aacotroneo\Saml2\Events\Saml2LogoutEvent;
 
 use Log;

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -59,11 +59,11 @@ class Saml2Auth
      * Initiate a saml2 logout flow. It will close session on all other SSO services. You should close
      * local session if applicable.
      */
-    function logout($returnTo = null, $nameId = null, $sessionIndex = null)
+    function logout($returnTo = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null)
     {
         $auth = $this->auth;
 
-        $auth->logout($returnTo, [], $nameId, $sessionIndex);
+        $auth->logout($returnTo, [], $nameId, $sessionIndex, false, $nameIdFormat);
     }
 
     /**

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -1,7 +1,8 @@
 <?php
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Utils as OneLogin_Saml2_Utils;
 use URL;
 use Illuminate\Support\ServiceProvider;
 
@@ -31,7 +32,7 @@ class Saml2ServiceProvider extends ServiceProvider
         ]);
 
         if (config('saml2_settings.proxyVars', false)) {
-            \OneLogin_Saml2_Utils::setProxyVars(true);
+            OneLogin_Saml2_Utils::setProxyVars(true);
         }
     }
 

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -1,7 +1,8 @@
 <?php
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Utils as OneLogin_Saml2_Utils;
 use URL;
 use Illuminate\Support\ServiceProvider;
 
@@ -30,6 +31,10 @@ class Saml2ServiceProvider extends ServiceProvider
             __DIR__.'/../../config/saml2_settings.php' => config_path('saml2_settings.php'),
             __DIR__.'/../../config/test_idp_settings.php' => config_path('saml.test_idp_settings.php'),
         ]);
+
+        if (config('saml2_settings.proxyVars', false)) {
+            OneLogin_Saml2_Utils::setProxyVars(true);
+        }
     }
 
     /**

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -65,6 +65,15 @@ class Saml2ServiceProvider extends ServiceProvider
                 empty($config['sp']['singleLogoutService']['url'])) {
                 $config['sp']['singleLogoutService']['url'] = URL::route('saml_sls');
             }
+            if (strpos($config['sp']['privateKey'], 'file://')===0) {
+                $config['sp']['privateKey'] = $this->extractPkeyFromFile($config['sp']['privateKey']);
+            }
+            if (strpos($config['sp']['x509cert'], 'file://')===0) {
+                $config['sp']['x509cert'] = $this->extractCertFromFile($config['sp']['x509cert']);
+            }
+            if (strpos($config['idp']['x509cert'], 'file://')===0) {
+                $config['idp']['x509cert'] = $this->extractCertFromFile($config['idp']['x509cert']);
+            }
 
             return new OneLogin_Saml2_Auth($config);
         });
@@ -80,4 +89,30 @@ class Saml2ServiceProvider extends ServiceProvider
         return array();
     }
 
+    protected function extractPkeyFromFile($path) {
+        $res = openssl_get_privatekey($path);
+        if (empty($res)) {
+            throw new \Exception('Could not read private key-file at path \'' . $path . '\'');
+        }
+        openssl_pkey_export($res, $pkey);
+        openssl_pkey_free($res);
+        return $this->extractOpensslString($pkey, 'PRIVATE KEY');
+    }
+
+    protected function extractCertFromFile($path) {
+        $res = openssl_x509_read(file_get_contents($path));
+        if (empty($res)) {
+            throw new \Exception('Could not read X509 certificate-file at path \'' . $path . '\'');
+        }
+        openssl_x509_export($res, $cert);
+        openssl_x509_free($res);
+        return $this->extractOpensslString($cert, 'CERTIFICATE');
+    }
+
+    protected function extractOpensslString($keyString, $delimiter) {
+        $keyString = str_replace(["\r", "\n"], "", $keyString);
+        $regex = '/-{5}BEGIN(?:\s|\w)+' . $delimiter . '-{5}\s*(.+?)\s*-{5}END(?:\s|\w)+' . $delimiter . '-{5}/m';
+        preg_match($regex, $keyString, $matches);
+        return empty($matches[1]) ? '' : $matches[1];
+    }
 }

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -42,8 +42,18 @@ class Saml2ServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->registerOneLoginInContainer();
 
         $this->app->singleton('Aacotroneo\Saml2\Saml2Auth', function ($app) {
+
+            return new \Aacotroneo\Saml2\Saml2Auth($app['OneLogin_Saml2_Auth']);
+        });
+
+    }
+
+    protected function registerOneLoginInContainer()
+    {
+        $this->app->singleton('OneLogin_Saml2_Auth', function ($app) {
             $config = config('saml2_settings');
             if (empty($config['sp']['entityId'])) {
                 $config['sp']['entityId'] = URL::route('saml_metadata');
@@ -52,15 +62,12 @@ class Saml2ServiceProvider extends ServiceProvider
                 $config['sp']['assertionConsumerService']['url'] = URL::route('saml_acs');
             }
             if (!empty($config['sp']['singleLogoutService']) &&
-                 empty($config['sp']['singleLogoutService']['url'])) {
+                empty($config['sp']['singleLogoutService']['url'])) {
                 $config['sp']['singleLogoutService']['url'] = URL::route('saml_sls');
             }
 
-            $auth = new OneLogin_Saml2_Auth($config);
-
-            return new \Aacotroneo\Saml2\Saml2Auth($auth);
+            return new OneLogin_Saml2_Auth($config);
         });
-
     }
 
     /**

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -29,6 +29,10 @@ class Saml2ServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../../config/saml2_settings.php' => config_path('saml2_settings.php'),
         ]);
+
+        if (config('saml2_settings.proxyVars', false)) {
+            \OneLogin_Saml2_Utils::setProxyVars(true);
+        }
     }
 
     /**
@@ -47,7 +51,8 @@ class Saml2ServiceProvider extends ServiceProvider
             if (empty($config['sp']['assertionConsumerService']['url'])) {
                 $config['sp']['assertionConsumerService']['url'] = URL::route('saml_acs');
             }
-            if (empty($config['sp']['singleLogoutService']['url'])) {
+            if (!empty($config['sp']['singleLogoutService']) &&
+                 empty($config['sp']['singleLogoutService']['url'])) {
                 $config['sp']['singleLogoutService']['url'] = URL::route('saml_sls');
             }
 

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -41,12 +41,15 @@ class Saml2ServiceProvider extends ServiceProvider
 
         $this->app->singleton('Aacotroneo\Saml2\Saml2Auth', function ($app) {
             $config = config('saml2_settings');
-
-            $config['sp']['entityId'] = URL::route('saml_metadata');
-
-            $config['sp']['assertionConsumerService']['url'] = URL::route('saml_acs');
-
-            $config['sp']['singleLogoutService']['url'] = URL::route('saml_sls');
+            if (empty($config['sp']['entityId'])) {
+                $config['sp']['entityId'] = URL::route('saml_metadata');
+            }
+            if (empty($config['sp']['assertionConsumerService']['url'])) {
+                $config['sp']['assertionConsumerService']['url'] = URL::route('saml_acs');
+            }
+            if (empty($config['sp']['singleLogoutService']['url'])) {
+                $config['sp']['singleLogoutService']['url'] = URL::route('saml_sls');
+            }
 
             $auth = new OneLogin_Saml2_Auth($config);
 

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -29,6 +29,10 @@ class Saml2ServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../../config/saml2_settings.php' => config_path('saml2_settings.php'),
         ]);
+
+        if (config('saml2_settings.proxyVars', false)) {
+            \OneLogin_Saml2_Utils::setProxyVars(true);
+        }
     }
 
     /**

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -47,7 +47,8 @@ class Saml2ServiceProvider extends ServiceProvider
             if (empty($config['sp']['assertionConsumerService']['url'])) {
                 $config['sp']['assertionConsumerService']['url'] = URL::route('saml_acs');
             }
-            if (empty($config['sp']['singleLogoutService']['url'])) {
+            if (!empty($config['sp']['singleLogoutService']) &&
+                 empty($config['sp']['singleLogoutService']['url'])) {
                 $config['sp']['singleLogoutService']['url'] = URL::route('saml_sls');
             }
 

--- a/src/Aacotroneo/Saml2/Saml2User.php
+++ b/src/Aacotroneo/Saml2/Saml2User.php
@@ -2,7 +2,7 @@
 
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
 
 /**
  * A simple class that represents the user that 'came' inside the saml2 assertion
@@ -41,6 +41,28 @@ class Saml2User
     }
 
     /**
+     * Returns the requested SAML attribute
+     *
+     * @param string $name The requested attribute of the user.
+     * @return array|null Requested SAML attribute ($name).
+     */
+    function getAttribute($name) {
+        $auth = $this->auth;
+
+        return $auth->getAttribute($name);
+    }
+    
+    /**
+     * @return array attributes retrieved from assertion processed this request
+     */
+    function getAttributesWithFriendlyName()
+    {
+        $auth = $this->auth;
+
+        return $auth->getAttributesWithFriendlyName();
+    }
+
+    /**
      * @return string the saml assertion processed this request
      */
     function getRawSamlAssertion()
@@ -57,6 +79,35 @@ class Saml2User
         if ($relayState && $url->full() != $relayState) {
 
             return $relayState;
+        }
+    }
+
+    /**
+     * Parses a SAML property and adds this property to this user or returns the value
+     *
+     * @param string $samlAttribute
+     * @param string $propertyName
+     * @return array|null
+     */
+    function parseUserAttribute($samlAttribute = null, $propertyName = null) {
+        if(empty($samlAttribute)) {
+            return null;
+        }
+        if(empty($propertyName)) {
+            return $this->getAttribute($samlAttribute);
+        }
+
+        return $this->{$propertyName} = $this->getAttribute($samlAttribute);
+    }
+
+    /**
+     * Parse the saml attributes and adds it to this user
+     *
+     * @param array $attributes Array of properties which need to be parsed, like this ['email' => 'urn:oid:0.9.2342.19200300.100.1.3']
+     */
+    function parseAttributes($attributes = array()) {
+        foreach($attributes as $propertyName => $samlAttribute) {
+            $this->parseUserAttribute($samlAttribute, $propertyName);
         }
     }
 

--- a/src/Aacotroneo/Saml2/Saml2User.php
+++ b/src/Aacotroneo/Saml2/Saml2User.php
@@ -41,6 +41,18 @@ class Saml2User
     }
 
     /**
+     * Returns the requested SAML attribute
+     *
+     * @param string $name The requested attribute of the user.
+     * @return array|null Requested SAML attribute ($name).
+     */
+    function getAttribute($name) {
+        $auth = $this->auth;
+
+        return $auth->getAttribute($name);
+    }
+
+    /**
      * @return string the saml assertion processed this request
      */
     function getRawSamlAssertion()
@@ -57,6 +69,35 @@ class Saml2User
         if ($relayState && $url->full() != $relayState) {
 
             return $relayState;
+        }
+    }
+
+    /**
+     * Parses a SAML property and adds this property to this user or returns the value
+     *
+     * @param string $samlAttribute
+     * @param string $propertyName
+     * @return array|null
+     */
+    function parseUserAttribute($samlAttribute = null, $propertyName = null) {
+        if(empty($samlAttribute)) {
+            return null;
+        }
+        if(empty($propertyName)) {
+            return $this->getAttribute($samlAttribute);
+        }
+
+        return $this->{$propertyName} = $this->getAttribute($samlAttribute);
+    }
+
+    /**
+     * Parse the saml attributes and adds it to this user
+     *
+     * @param array $attributes Array of properties which need to be parsed, like this ['email' => 'urn:oid:0.9.2342.19200300.100.1.3']
+     */
+    function parseAttributes($attributes = array()) {
+        foreach($attributes as $propertyName => $samlAttribute) {
+            $this->parseUserAttribute($samlAttribute, $propertyName);
         }
     }
 

--- a/src/Aacotroneo/Saml2/Saml2User.php
+++ b/src/Aacotroneo/Saml2/Saml2User.php
@@ -2,7 +2,7 @@
 
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
 
 /**
  * A simple class that represents the user that 'came' inside the saml2 assertion

--- a/src/Aacotroneo/Saml2/Saml2User.php
+++ b/src/Aacotroneo/Saml2/Saml2User.php
@@ -51,6 +51,16 @@ class Saml2User
 
         return $auth->getAttribute($name);
     }
+    
+    /**
+     * @return array attributes retrieved from assertion processed this request
+     */
+    function getAttributesWithFriendlyName()
+    {
+        $auth = $this->auth;
+
+        return $auth->getAttributesWithFriendlyName();
+    }
 
     /**
      * @return string the saml assertion processed this request

--- a/src/config/saml2_settings.php
+++ b/src/config/saml2_settings.php
@@ -1,7 +1,7 @@
 <?php
 
 //This is variable is an example - Just make sure that the urls in the 'idp' config are ok.
-$idp_host = 'http://localhost:8000/simplesaml';
+$idp_host = env('SAML2_IDP_HOST', 'http://localhost:8000/simplesaml');
 
 return $settings = array(
 
@@ -64,7 +64,7 @@ return $settings = array(
     'strict' => true, //@todo: make this depend on laravel config
 
     // Enable debug mode (to print errors)
-    'debug' => false, //@todo: make this depend on laravel config,
+    'debug' => env('APP_DEBUG', false),
 
     // If 'proxyVars' is True, then the Saml lib will trust proxy headers
     // e.g X-Forwarded-Proto / HTTP_X_FORWARDED_PROTO. This is useful if
@@ -82,12 +82,12 @@ return $settings = array(
 
         // Usually x509cert and privateKey of the SP are provided by files placed at
         // the certs folder. But we can also provide them with the following parameters
-        'x509cert' => '',
-        'privateKey' => '',
+        'x509cert' => env('SAML2_SP_x509',''),
+        'privateKey' => env('SAML2_SP_PRIVATEKEY',''),
 
         // Identifier (URI) of the SP entity.
         // Leave blank to use the 'saml_metadata' route.
-        'entityId' => '',
+        'entityId' => env('SAML2_SP_ENTITYID',''),
 
         // Specifies info about where and how the <AuthnResponse> message MUST be
         // returned to the requester, in this case our SP.
@@ -111,7 +111,7 @@ return $settings = array(
     // Identity Provider Data that we want connect with our SP
     'idp' => array(
         // Identifier of the IdP entity  (must be a URI)
-        'entityId' => $idp_host . '/saml2/idp/metadata.php',
+        'entityId' => env('SAML2_IDP_ENTITYID', $idp_host . '/saml2/idp/metadata.php'),
         // SSO endpoint info of the IdP. (Authentication Request protocol)
         'singleSignOnService' => array(
             // URL Target of the IdP where the SP will send the Authentication Request Message,
@@ -125,7 +125,7 @@ return $settings = array(
             'url' => $idp_host . '/saml2/idp/SingleLogoutService.php',
         ),
         // Public x509 certificate of the IdP
-        'x509cert' => 'MIID/TCCAuWgAwIBAgIJAI4R3WyjjmB1MA0GCSqGSIb3DQEBCwUAMIGUMQswCQYDVQQGEwJBUjEVMBMGA1UECAwMQnVlbm9zIEFpcmVzMRUwEwYDVQQHDAxCdWVub3MgQWlyZXMxDDAKBgNVBAoMA1NJVTERMA8GA1UECwwIU2lzdGVtYXMxFDASBgNVBAMMC09yZy5TaXUuQ29tMSAwHgYJKoZIhvcNAQkBFhFhZG1pbmlAc2l1LmVkdS5hcjAeFw0xNDEyMDExNDM2MjVaFw0yNDExMzAxNDM2MjVaMIGUMQswCQYDVQQGEwJBUjEVMBMGA1UECAwMQnVlbm9zIEFpcmVzMRUwEwYDVQQHDAxCdWVub3MgQWlyZXMxDDAKBgNVBAoMA1NJVTERMA8GA1UECwwIU2lzdGVtYXMxFDASBgNVBAMMC09yZy5TaXUuQ29tMSAwHgYJKoZIhvcNAQkBFhFhZG1pbmlAc2l1LmVkdS5hcjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMbzW/EpEv+qqZzfT1Buwjg9nnNNVrxkCfuR9fQiQw2tSouS5X37W5h7RmchRt54wsm046PDKtbSz1NpZT2GkmHN37yALW2lY7MyVUC7itv9vDAUsFr0EfKIdCKgxCKjrzkZ5ImbNvjxf7eA77PPGJnQ/UwXY7W+cvLkirp0K5uWpDk+nac5W0JXOCFR1BpPUJRbz2jFIEHyChRt7nsJZH6ejzNqK9lABEC76htNy1Ll/D3tUoPaqo8VlKW3N3MZE0DB9O7g65DmZIIlFqkaMH3ALd8adodJtOvqfDU/A6SxuwMfwDYPjoucykGDu1etRZ7dF2gd+W+1Pn7yizPT1q8CAwEAAaNQME4wHQYDVR0OBBYEFPsn8tUHN8XXf23ig5Qro3beP8BuMB8GA1UdIwQYMBaAFPsn8tUHN8XXf23ig5Qro3beP8BuMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGu60odWFiK+DkQekozGnlpNBQz5lQ/bwmOWdktnQj6HYXu43e7sh9oZWArLYHEOyMUekKQAxOK51vbTHzzw66BZU91/nqvaOBfkJyZKGfluHbD0/hfOl/D5kONqI9kyTu4wkLQcYGyuIi75CJs15uA03FSuULQdY/Liv+czS/XYDyvtSLnu43VuAQWN321PQNhuGueIaLJANb2C5qq5ilTBUw6PxY9Z+vtMjAjTJGKEkE/tQs7CvzLPKXX3KTD9lIILmX5yUC3dLgjVKi1KGDqNApYGOMtjr5eoxPQrqDBmyx3flcy0dQTdLXud3UjWVW3N0PYgJtw5yBsS74QTGD4=',
+        'x509cert' => env('SAML2_IDP_x509', 'MIID/TCCAuWgAwIBAgIJAI4R3WyjjmB1MA0GCSqGSIb3DQEBCwUAMIGUMQswCQYDVQQGEwJBUjEVMBMGA1UECAwMQnVlbm9zIEFpcmVzMRUwEwYDVQQHDAxCdWVub3MgQWlyZXMxDDAKBgNVBAoMA1NJVTERMA8GA1UECwwIU2lzdGVtYXMxFDASBgNVBAMMC09yZy5TaXUuQ29tMSAwHgYJKoZIhvcNAQkBFhFhZG1pbmlAc2l1LmVkdS5hcjAeFw0xNDEyMDExNDM2MjVaFw0yNDExMzAxNDM2MjVaMIGUMQswCQYDVQQGEwJBUjEVMBMGA1UECAwMQnVlbm9zIEFpcmVzMRUwEwYDVQQHDAxCdWVub3MgQWlyZXMxDDAKBgNVBAoMA1NJVTERMA8GA1UECwwIU2lzdGVtYXMxFDASBgNVBAMMC09yZy5TaXUuQ29tMSAwHgYJKoZIhvcNAQkBFhFhZG1pbmlAc2l1LmVkdS5hcjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMbzW/EpEv+qqZzfT1Buwjg9nnNNVrxkCfuR9fQiQw2tSouS5X37W5h7RmchRt54wsm046PDKtbSz1NpZT2GkmHN37yALW2lY7MyVUC7itv9vDAUsFr0EfKIdCKgxCKjrzkZ5ImbNvjxf7eA77PPGJnQ/UwXY7W+cvLkirp0K5uWpDk+nac5W0JXOCFR1BpPUJRbz2jFIEHyChRt7nsJZH6ejzNqK9lABEC76htNy1Ll/D3tUoPaqo8VlKW3N3MZE0DB9O7g65DmZIIlFqkaMH3ALd8adodJtOvqfDU/A6SxuwMfwDYPjoucykGDu1etRZ7dF2gd+W+1Pn7yizPT1q8CAwEAAaNQME4wHQYDVR0OBBYEFPsn8tUHN8XXf23ig5Qro3beP8BuMB8GA1UdIwQYMBaAFPsn8tUHN8XXf23ig5Qro3beP8BuMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGu60odWFiK+DkQekozGnlpNBQz5lQ/bwmOWdktnQj6HYXu43e7sh9oZWArLYHEOyMUekKQAxOK51vbTHzzw66BZU91/nqvaOBfkJyZKGfluHbD0/hfOl/D5kONqI9kyTu4wkLQcYGyuIi75CJs15uA03FSuULQdY/Liv+czS/XYDyvtSLnu43VuAQWN321PQNhuGueIaLJANb2C5qq5ilTBUw6PxY9Z+vtMjAjTJGKEkE/tQs7CvzLPKXX3KTD9lIILmX5yUC3dLgjVKi1KGDqNApYGOMtjr5eoxPQrqDBmyx3flcy0dQTdLXud3UjWVW3N0PYgJtw5yBsS74QTGD4='),
         /*
          *  Instead of use the whole x509cert you can use a fingerprint
          *  (openssl x509 -noout -fingerprint -in "idp.crt" to generate it)

--- a/src/config/saml2_settings.php
+++ b/src/config/saml2_settings.php
@@ -4,11 +4,19 @@
 $idp_host = 'http://localhost:8000/simplesaml';
 
 return $settings = array(
-    /*****
-     * Cosmetic settings - controller routes
-     **/
-    'useRoutes' => true, //include library routes and controllers
 
+    /**
+     * If 'useRoutes' is set to true, the package defines five new routes:
+     *
+     *    Method | URI                      | Name
+     *    -------|--------------------------|------------------
+     *    POST   | {routesPrefix}/acs       | saml_acs
+     *    GET    | {routesPrefix}/login     | saml_login
+     *    GET    | {routesPrefix}/logout    | saml_logout
+     *    GET    | {routesPrefix}/metadata  | saml_metadata
+     *    GET    | {routesPrefix}/sls       | saml_sls
+     */
+    'useRoutes' => true,
 
     'routesPrefix' => '/saml2',
 
@@ -71,28 +79,25 @@ return $settings = array(
         'x509cert' => '',
         'privateKey' => '',
 
-        //LARAVEL - You don't need to change anything else on the sp
-        // Identifier of the SP entity  (must be a URI)
-        'entityId' => '', //LARAVEL: This would be set to saml_metadata route
+        // Identifier (URI) of the SP entity.
+        // Leave blank to use the 'saml_metadata' route.
+        'entityId' => '',
+
         // Specifies info about where and how the <AuthnResponse> message MUST be
         // returned to the requester, in this case our SP.
         'assertionConsumerService' => array(
-            // URL Location where the <Response> from the IdP will be returned
-            'url' => '', //LARAVEL: This would be set to saml_acs route
-            // SAML protocol binding to be used when returning the <Response>
-            // message.  Onelogin Toolkit supports for this endpoint the
-            // HTTP-Redirect binding only
-            'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+            // URL Location where the <Response> from the IdP will be returned,
+            // using HTTP-POST binding.
+            // Leave blank to use the 'saml_acs' route
+            'url' => '',
         ),
         // Specifies info about where and how the <Logout Response> message MUST be
         // returned to the requester, in this case our SP.
         'singleLogoutService' => array(
-            // URL Location where the <Response> from the IdP will be returned
-            'url' => '', //LARAVEL: This would be set to saml_sls route
-            // SAML protocol binding to be used when returning the <Response>
-            // message.  Onelogin Toolkit supports for this endpoint the
-            // HTTP-Redirect binding only
-            'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+            // URL Location where the <Response> from the IdP will be returned,
+            // using HTTP-Redirect binding.
+            // Leave blank to use the 'saml_sls' route
+            'url' => '',
         ),
     ),
 
@@ -102,21 +107,15 @@ return $settings = array(
         'entityId' => $idp_host . '/saml2/idp/metadata.php',
         // SSO endpoint info of the IdP. (Authentication Request protocol)
         'singleSignOnService' => array(
-            // URL Target of the IdP where the SP will send the Authentication Request Message
+            // URL Target of the IdP where the SP will send the Authentication Request Message,
+            // using HTTP-Redirect binding.
             'url' => $idp_host . '/saml2/idp/SSOService.php',
-            // SAML protocol binding to be used when returning the <Response>
-            // message.  Onelogin Toolkit supports for this endpoint the
-            // HTTP-POST binding only
-            'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
         ),
         // SLO endpoint info of the IdP.
         'singleLogoutService' => array(
-            // URL Location of the IdP where the SP will send the SLO Request
+            // URL Location of the IdP where the SP will send the SLO Request,
+            // using HTTP-Redirect binding.
             'url' => $idp_host . '/saml2/idp/SingleLogoutService.php',
-            // SAML protocol binding to be used when returning the <Response>
-            // message.  Onelogin Toolkit supports for this endpoint the
-            // HTTP-Redirect binding only
-            'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
         ),
         // Public x509 certificate of the IdP
         'x509cert' => 'MIID/TCCAuWgAwIBAgIJAI4R3WyjjmB1MA0GCSqGSIb3DQEBCwUAMIGUMQswCQYDVQQGEwJBUjEVMBMGA1UECAwMQnVlbm9zIEFpcmVzMRUwEwYDVQQHDAxCdWVub3MgQWlyZXMxDDAKBgNVBAoMA1NJVTERMA8GA1UECwwIU2lzdGVtYXMxFDASBgNVBAMMC09yZy5TaXUuQ29tMSAwHgYJKoZIhvcNAQkBFhFhZG1pbmlAc2l1LmVkdS5hcjAeFw0xNDEyMDExNDM2MjVaFw0yNDExMzAxNDM2MjVaMIGUMQswCQYDVQQGEwJBUjEVMBMGA1UECAwMQnVlbm9zIEFpcmVzMRUwEwYDVQQHDAxCdWVub3MgQWlyZXMxDDAKBgNVBAoMA1NJVTERMA8GA1UECwwIU2lzdGVtYXMxFDASBgNVBAMMC09yZy5TaXUuQ29tMSAwHgYJKoZIhvcNAQkBFhFhZG1pbmlAc2l1LmVkdS5hcjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMbzW/EpEv+qqZzfT1Buwjg9nnNNVrxkCfuR9fQiQw2tSouS5X37W5h7RmchRt54wsm046PDKtbSz1NpZT2GkmHN37yALW2lY7MyVUC7itv9vDAUsFr0EfKIdCKgxCKjrzkZ5ImbNvjxf7eA77PPGJnQ/UwXY7W+cvLkirp0K5uWpDk+nac5W0JXOCFR1BpPUJRbz2jFIEHyChRt7nsJZH6ejzNqK9lABEC76htNy1Ll/D3tUoPaqo8VlKW3N3MZE0DB9O7g65DmZIIlFqkaMH3ALd8adodJtOvqfDU/A6SxuwMfwDYPjoucykGDu1etRZ7dF2gd+W+1Pn7yizPT1q8CAwEAAaNQME4wHQYDVR0OBBYEFPsn8tUHN8XXf23ig5Qro3beP8BuMB8GA1UdIwQYMBaAFPsn8tUHN8XXf23ig5Qro3beP8BuMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGu60odWFiK+DkQekozGnlpNBQz5lQ/bwmOWdktnQj6HYXu43e7sh9oZWArLYHEOyMUekKQAxOK51vbTHzzw66BZU91/nqvaOBfkJyZKGfluHbD0/hfOl/D5kONqI9kyTu4wkLQcYGyuIi75CJs15uA03FSuULQdY/Liv+czS/XYDyvtSLnu43VuAQWN321PQNhuGueIaLJANb2C5qq5ilTBUw6PxY9Z+vtMjAjTJGKEkE/tQs7CvzLPKXX3KTD9lIILmX5yUC3dLgjVKi1KGDqNApYGOMtjr5eoxPQrqDBmyx3flcy0dQTdLXud3UjWVW3N0PYgJtw5yBsS74QTGD4=',

--- a/src/config/saml2_settings.php
+++ b/src/config/saml2_settings.php
@@ -64,7 +64,13 @@ return $settings = array(
     'strict' => true, //@todo: make this depend on laravel config
 
     // Enable debug mode (to print errors)
-    'debug' => false, //@todo: make this depend on laravel config
+    'debug' => false, //@todo: make this depend on laravel config,
+
+    // If 'proxyVars' is True, then the Saml lib will trust proxy headers
+    // e.g X-Forwarded-Proto / HTTP_X_FORWARDED_PROTO. This is useful if
+    // your application is running behind a load balancer which terminates
+    // SSL.
+    'proxyVars' => false,
 
     // Service Provider Data that we are deploying
     'sp' => array(

--- a/src/config/saml2_settings.php
+++ b/src/config/saml2_settings.php
@@ -64,7 +64,13 @@ return $settings = array(
     'strict' => true, //@todo: make this depend on laravel config
 
     // Enable debug mode (to print errors)
-    'debug' => false, //@todo: make this depend on laravel config
+    'debug' => false, //@todo: make this depend on laravel config,
+
+    // If 'proxyVars' is True, then the Saml lib will trust proxy headers
+    // e.g X-Forwarded-Proto / HTTP_X_FORWARDED_PROTO. This is useful if
+    // your application is running behind a load balancer which terminates
+    // SSL.
+    'proxyVars' => false,
 
     // Service Provider Data that we are deploying
     'sp' => array(
@@ -93,6 +99,7 @@ return $settings = array(
         ),
         // Specifies info about where and how the <Logout Response> message MUST be
         // returned to the requester, in this case our SP.
+        // Remove this part to not include any URL Location in the metadata.
         'singleLogoutService' => array(
             // URL Location where the <Response> from the IdP will be returned,
             // using HTTP-Redirect binding.

--- a/src/config/saml2_settings.php
+++ b/src/config/saml2_settings.php
@@ -6,13 +6,26 @@ return $settings = array(
      * Array of IDP prefixes to be configured e.g. 'idpNames' => ['test1', 'test2', 'test3'],
      * Separate routes will be automatically registered for each IDP specified with IDP name as prefix
      * Separate config file saml2/<idpName>_idp_settings.php should be added & configured accordingly
-     **/
+     */
     'idpNames' => ['test'],
 
     /**
-     * Cosmetic settings - controller routes
-     **/
-    'useRoutes' => true, //include library routes and controllers
+     * If 'useRoutes' is set to true, the package defines five new routes for reach entry in idpNames:
+     *
+     *    Method | URI                                | Name
+     *    -------|------------------------------------|------------------
+     *    POST   | {routesPrefix}/{idpName}/acs       | saml_acs
+     *    GET    | {routesPrefix}/{idpName}/login     | saml_login
+     *    GET    | {routesPrefix}/{idpName}/logout    | saml_logout
+     *    GET    | {routesPrefix}/{idpName}/metadata  | saml_metadata
+     *    GET    | {routesPrefix}/{idpName}/sls       | saml_sls
+     */
+    'useRoutes' => true,
+
+    /**
+     * Optional, leave empty if you want the defined routes to be top level, i.e. "/{idpName}/*"
+     */
+    'routesPrefix' => '/saml2',
 
     /**
      * which middleware group to use for the saml routes
@@ -36,10 +49,15 @@ return $settings = array(
      */
     'loginRoute' => '/',
 
-
     /**
      * Where to redirect after login if no other option was provided
      */
     'errorRoute' => '/',
+
+    // If 'proxyVars' is True, then the Saml lib will trust proxy headers
+    // e.g X-Forwarded-Proto / HTTP_X_FORWARDED_PROTO. This is useful if
+    // your application is running behind a load balancer which terminates
+    // SSL.
+    'proxyVars' => false,
 
 );

--- a/src/config/saml2_settings.php
+++ b/src/config/saml2_settings.php
@@ -93,6 +93,7 @@ return $settings = array(
         ),
         // Specifies info about where and how the <Logout Response> message MUST be
         // returned to the requester, in this case our SP.
+        // Remove this part to not include any URL Location in the metadata.
         'singleLogoutService' => array(
             // URL Location where the <Response> from the IdP will be returned,
             // using HTTP-Redirect binding.

--- a/src/routes.php
+++ b/src/routes.php
@@ -3,7 +3,7 @@
 foreach (config('saml2_settings.idpNames') as $key => $value) {
    
     Route::group([
-        'prefix' => $value,
+        'prefix' => config('saml2_settings.routesPrefix').'/'.$value,
         'middleware' => config('saml2_settings.routesMiddleware'),
     ], function () use ($value) {
         

--- a/tests/Saml2/Saml2AuthServiceProviderTest.php
+++ b/tests/Saml2/Saml2AuthServiceProviderTest.php
@@ -5,8 +5,9 @@ namespace Aacotroneo\Saml2;
 
 use App;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class Saml2AuthServiceProviderTest extends \PHPUnit_Framework_TestCase
+class Saml2AuthServiceProviderTest extends TestCase
 {
 
 

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -40,12 +40,13 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
         $expectedReturnTo = 'http://localhost';
         $expectedSessionIndex = 'session_index_value';
         $expectedNameId = 'name_id_value';
+        $expectedNameIdFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
         $auth = m::mock('OneLogin_Saml2_Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('logout')
-            ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex)
+            ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex, false, $expectedNameIdFormat)
             ->once();
-        $saml2->logout($expectedReturnTo, $expectedNameId, $expectedSessionIndex);
+        $saml2->logout($expectedReturnTo, $expectedNameId, $expectedSessionIndex, $expectedNameIdFormat);
     }
 
 

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -5,8 +5,9 @@ namespace Aacotroneo\Saml2;
 
 use App;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class Saml2AuthTest extends \PHPUnit_Framework_TestCase
+class Saml2AuthTest extends TestCase
 {
 
 
@@ -18,7 +19,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testIsAuthenticated()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $auth->shouldReceive('isAuthenticated')->andReturn('return');
@@ -29,7 +30,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testLogin()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('login')->once();
         $saml2->login();
@@ -43,7 +44,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
         $expectedNameIdFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
         $expectedStay = true;
         $expectedNameIdNameQualifier = 'name_id_name_qualifier';
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('logout')
             ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex, $expectedStay, $expectedNameIdFormat, $expectedNameIdNameQualifier)
@@ -54,7 +55,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testAcsError()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(array('errors'));
@@ -67,7 +68,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testAcsNotAutenticated()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -80,7 +81,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testAcsOK()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -93,7 +94,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testSlsError()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processSLO')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn('errors');
@@ -105,7 +106,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testSlsOK()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processSLO')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -117,7 +118,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testCanGetLastError()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $auth->shouldReceive('getLastErrorReason')->andReturn('lastError');
@@ -126,7 +127,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testGetUserAttribute() {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $user = $saml2->getSaml2User();
@@ -139,7 +140,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testParseSingleUserAttribute() {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $user = $saml2->getSaml2User();
@@ -154,7 +155,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
     }
 
     public function testParseMultipleUserAttributes() {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $user = $saml2->getSaml2User();

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -19,7 +19,7 @@ class Saml2AuthTest extends TestCase
 
     public function testIsAuthenticated()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $auth->shouldReceive('isAuthenticated')->andReturn('return');
@@ -30,7 +30,7 @@ class Saml2AuthTest extends TestCase
 
     public function testLogin()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('login')->once();
         $saml2->login();
@@ -44,7 +44,7 @@ class Saml2AuthTest extends TestCase
         $expectedNameIdFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
         $expectedStay = true;
         $expectedNameIdNameQualifier = 'name_id_name_qualifier';
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('logout')
             ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex, $expectedStay, $expectedNameIdFormat, $expectedNameIdNameQualifier)
@@ -55,7 +55,7 @@ class Saml2AuthTest extends TestCase
 
     public function testAcsError()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(array('errors'));
@@ -68,7 +68,7 @@ class Saml2AuthTest extends TestCase
 
     public function testAcsNotAutenticated()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -81,7 +81,7 @@ class Saml2AuthTest extends TestCase
 
     public function testAcsOK()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -94,7 +94,7 @@ class Saml2AuthTest extends TestCase
 
     public function testSlsError()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processSLO')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn('errors');
@@ -106,7 +106,7 @@ class Saml2AuthTest extends TestCase
 
     public function testSlsOK()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processSLO')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -118,7 +118,7 @@ class Saml2AuthTest extends TestCase
 
     public function testCanGetLastError()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $auth->shouldReceive('getLastErrorReason')->andReturn('lastError');
@@ -127,7 +127,7 @@ class Saml2AuthTest extends TestCase
     }
 
     public function testGetUserAttribute() {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $user = $saml2->getSaml2User();
@@ -140,7 +140,7 @@ class Saml2AuthTest extends TestCase
     }
 
     public function testParseSingleUserAttribute() {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $user = $saml2->getSaml2User();
@@ -155,7 +155,7 @@ class Saml2AuthTest extends TestCase
     }
 
     public function testParseMultipleUserAttributes() {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $user = $saml2->getSaml2User();

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -5,8 +5,9 @@ namespace Aacotroneo\Saml2;
 
 use App;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class Saml2AuthTest extends \PHPUnit_Framework_TestCase
+class Saml2AuthTest extends TestCase
 {
 
 

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -112,6 +112,16 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($error);
     }
 
+    public function testCanGetLastError()
+    {
+        $auth = m::mock('OneLogin_Saml2_Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $auth->shouldReceive('getLastErrorReason')->andReturn('lastError');
+
+        $this->assertSame('lastError', $saml2->getLastErrorReason());
+    }
+
 /**
          * Cant test here. It uses Laravel dependencies (eg. config())
          */

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -5,8 +5,9 @@ namespace Aacotroneo\Saml2;
 
 use App;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class Saml2AuthTest extends \PHPUnit_Framework_TestCase
+class Saml2AuthTest extends TestCase
 {
 
 
@@ -18,7 +19,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testIsAuthenticated()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $auth->shouldReceive('isAuthenticated')->andReturn('return');
@@ -29,7 +30,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testLogin()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('login')->once();
         $saml2->login();
@@ -40,18 +41,21 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
         $expectedReturnTo = 'http://localhost';
         $expectedSessionIndex = 'session_index_value';
         $expectedNameId = 'name_id_value';
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $expectedNameIdFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
+        $expectedStay = true;
+        $expectedNameIdNameQualifier = 'name_id_name_qualifier';
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('logout')
-            ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex)
+            ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex, $expectedStay, $expectedNameIdFormat, $expectedNameIdNameQualifier)
             ->once();
-        $saml2->logout($expectedReturnTo, $expectedNameId, $expectedSessionIndex);
+        $saml2->logout($expectedReturnTo, $expectedNameId, $expectedSessionIndex, $expectedNameIdFormat, $expectedStay, $expectedNameIdNameQualifier);
     }
 
 
     public function testAcsError()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(array('errors'));
@@ -65,7 +69,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testAcsNotAutenticated()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -79,7 +83,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testAcsOK()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -92,7 +96,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testSlsError()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processSLO')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn('errors');
@@ -105,7 +109,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testSlsOK()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processSLO')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -113,6 +117,63 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
         $error =  $saml2->sls('test');
 
         $this->assertEmpty($error);
+    }
+
+    public function testCanGetLastError()
+    {
+        $auth = m::mock('OneLogin\Saml2\Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $auth->shouldReceive('getLastErrorReason')->andReturn('lastError');
+
+        $this->assertSame('lastError', $saml2->getLastErrorReason());
+    }
+
+    public function testGetUserAttribute() {
+        $auth = m::mock('OneLogin\Saml2\Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $user = $saml2->getSaml2User();
+
+        $auth->shouldReceive('getAttribute')
+            ->with('urn:oid:0.9.2342.19200300.100.1.3')
+            ->andReturn(['test@example.com']);
+
+        $this->assertEquals(['test@example.com'], $user->getAttribute('urn:oid:0.9.2342.19200300.100.1.3'));
+    }
+
+    public function testParseSingleUserAttribute() {
+        $auth = m::mock('OneLogin\Saml2\Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $user = $saml2->getSaml2User();
+
+        $auth->shouldReceive('getAttribute')
+            ->with('urn:oid:0.9.2342.19200300.100.1.3')
+            ->andReturn(['test@example.com']);
+
+        $user->parseUserAttribute('urn:oid:0.9.2342.19200300.100.1.3', 'email');
+
+        $this->assertEquals($user->email, ['test@example.com']);
+    }
+
+    public function testParseMultipleUserAttributes() {
+        $auth = m::mock('OneLogin\Saml2\Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $user = $saml2->getSaml2User();
+
+        $auth->shouldReceive('getAttribute')
+            ->twice()
+            ->andReturn(['test@example.com'], ['Test User']);
+
+        $user->parseAttributes([
+            'email' => 'urn:oid:0.9.2342.19200300.100.1.3',
+            'displayName' => 'urn:oid:2.16.840.1.113730.3.1.241'
+        ]);
+
+        $this->assertEquals($user->email, ['test@example.com']);
+        $this->assertEquals($user->displayName, ['Test User']);
     }
 
 /**

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -41,12 +41,14 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
         $expectedSessionIndex = 'session_index_value';
         $expectedNameId = 'name_id_value';
         $expectedNameIdFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
+        $expectedStay = true;
+        $expectedNameIdNameQualifier = 'name_id_name_qualifier';
         $auth = m::mock('OneLogin_Saml2_Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('logout')
-            ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex, false, $expectedNameIdFormat)
+            ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex, $expectedStay, $expectedNameIdFormat, $expectedNameIdNameQualifier)
             ->once();
-        $saml2->logout($expectedReturnTo, $expectedNameId, $expectedSessionIndex, $expectedNameIdFormat);
+        $saml2->logout($expectedReturnTo, $expectedNameId, $expectedSessionIndex, $expectedNameIdFormat, $expectedStay, $expectedNameIdNameQualifier);
     }
 
 

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -123,6 +123,53 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('lastError', $saml2->getLastErrorReason());
     }
 
+    public function testGetUserAttribute() {
+        $auth = m::mock('OneLogin_Saml2_Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $user = $saml2->getSaml2User();
+
+        $auth->shouldReceive('getAttribute')
+            ->with('urn:oid:0.9.2342.19200300.100.1.3')
+            ->andReturn(['test@example.com']);
+
+        $this->assertEquals(['test@example.com'], $user->getAttribute('urn:oid:0.9.2342.19200300.100.1.3'));
+    }
+
+    public function testParseSingleUserAttribute() {
+        $auth = m::mock('OneLogin_Saml2_Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $user = $saml2->getSaml2User();
+
+        $auth->shouldReceive('getAttribute')
+            ->with('urn:oid:0.9.2342.19200300.100.1.3')
+            ->andReturn(['test@example.com']);
+
+        $user->parseUserAttribute('urn:oid:0.9.2342.19200300.100.1.3', 'email');
+
+        $this->assertEquals($user->email, ['test@example.com']);
+    }
+
+    public function testParseMultipleUserAttributes() {
+        $auth = m::mock('OneLogin_Saml2_Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $user = $saml2->getSaml2User();
+
+        $auth->shouldReceive('getAttribute')
+            ->twice()
+            ->andReturn(['test@example.com'], ['Test User']);
+
+        $user->parseAttributes([
+            'email' => 'urn:oid:0.9.2342.19200300.100.1.3',
+            'displayName' => 'urn:oid:2.16.840.1.113730.3.1.241'
+        ]);
+
+        $this->assertEquals($user->email, ['test@example.com']);
+        $this->assertEquals($user->displayName, ['Test User']);
+    }
+
 /**
          * Cant test here. It uses Laravel dependencies (eg. config())
          */


### PR DESCRIPTION
@nirajp would you be interested in this PR which syncs the nirajp/laravel-saml2 fork
with the latest accotroneo?

If it is acceptable to you, it would bring nirajp/laravel-saml2 back to being additions on the head of aacotroneo/laravel-saml2 master. This would make your fork usable with PHP 7.1+.

---

I found the need to do this because I wanted the useful nirajp/laravel-saml2 fork for its
support for multiple IdPs, but in the almost 3 years that have passed,
mcrypt used by onelogin v2 has been deprecated/removed in PHP 7.1/7.2.
The upstream project updated to use onelogin v3, but this fork
did not get those changes yet.

This PR syncs with the latest
[aacotroneo/laravel-saml2](https://github.com/aacotroneo/laravel-saml2), which
brings in the onelogin v3 update, as well as a bunch of other additions
to the upstream repo.

#### Merge notes:
- Upstream changes were made in `register()` where the onelogin config
is prepared; in this commit those changes are moved to the
Saml2Controller constructor, which is where this fork moved onelogin
instantiation.
- Brings proxyVars setting into saml2_config.php
- Adds the new (optional) routesPrefix saml2_config.php setting. Changes
to routes.php to use it as an (optional) prefix to all the idp-specific
generated routes, and to Saml2Controller constructor's parsing of the path.
- Upstream added optional ENV vars for IdP and SP config. This commit
makes the same possible on a per-IdP basis, by providing a pattern for
the IdP configs to specify IdP-specific SAML2_* ENV var naming.
- Update README.md to reflect the new configuration options such as the ENV vars,
in the context of this fork's support for multiple IdPs.
- Bump version number. (Upstream is now 1.0.0, so I chose that too)